### PR TITLE
Fix for calling Exception from within a namespace

### DIFF
--- a/src/BackgroundProcess.php
+++ b/src/BackgroundProcess.php
@@ -56,6 +56,7 @@ class BackgroundProcess
 			    shell_exec(sprintf($cmd, $this->command, $outputFile));
 			    break;
 		    case 2:
+			case 3:
 			    $cmd = "%s > %s 2>&1 & echo $!";
 			    $this->pid = shell_exec(sprintf($cmd, $this->command, $outputFile));
 			    break;
@@ -112,16 +113,17 @@ class BackgroundProcess
 	/**
 	 * serverOS() protected method
 	 * returns integer, 1 if Windows, 2 if Linux, 3 if other
-	 * 
+	 *
 	 * @return int
 	 */
 	protected function serverOS()
 	{
 		$sys = strtoupper(PHP_OS);
 
-		if(substr($sys,0,3) == "WIN") { $os = 1; }
-		elseif($sys == "LINUX") { $os = 2; }
-		else { $os = 3; }
+		if(substr($sys,0,3) == "WIN") { $os = 1; } #Windows
+		elseif($sys == "Linux") { $os = 2; } #Linux
+		elseif($sys == "Darwin") { $os = 3; } #Mac OS X
+		else { $os = 4; }
 
 		return $os;
 	}

--- a/src/BackgroundProcess.php
+++ b/src/BackgroundProcess.php
@@ -26,6 +26,9 @@ class BackgroundProcess
     /** @var integer */
     private $pid;
 
+	/** @var $serverOS int */
+	protected $serverOS;
+
     /**
      * Constructor.
      *
@@ -34,22 +37,32 @@ class BackgroundProcess
     public function __construct($command)
     {
         $this->command = $command;
+	    $this->serverOS = $this->serverOS();
     }
 
     /**
      * Runs the command in a background process.
      *
      * @param string $outputFile File to write the output of the process to; defaults to /dev/null
+     * currently $outputFile has no effect when used in conjunction with a Windows server
      *
      * @return void
      */
     public function run($outputFile = '/dev/null')
     {
-        $this->pid = shell_exec(sprintf(
-            '%s > %s 2>&1 & echo $!',
-            $this->command,
-            $outputFile
-        ));
+	    switch($this->serverOS){
+		    case 1:
+				$cmd = "%s &";
+			    shell_exec(sprintf($cmd, $this->command, $outputFile));
+			    break;
+		    case 2:
+			    $cmd = "%s > %s 2>&1 & echo $!";
+			    $this->pid = shell_exec(sprintf($cmd, $this->command, $outputFile));
+			    break;
+		    default:
+			    die("we don't recognise you're server's OS");
+			    break;
+	    }
     }
 
     /**
@@ -95,4 +108,21 @@ class BackgroundProcess
     {
         return $this->pid;
     }
+
+	/**
+	 * serverOS() protected method
+	 * returns integer, 1 if Windows, 2 if Linux, 3 if other
+	 * 
+	 * @return int
+	 */
+	protected function serverOS()
+	{
+		$sys = strtoupper(PHP_OS);
+
+		if(substr($sys,0,3) == "WIN") { $os = 1; }
+		elseif($sys == "LINUX") { $os = 2; }
+		else { $os = 3; }
+
+		return $os;
+	}
 }

--- a/src/BackgroundProcess.php
+++ b/src/BackgroundProcess.php
@@ -64,7 +64,7 @@ class BackgroundProcess
             if(count(preg_split("/\n/", $result)) > 2) {
                 return true;
             }
-        } catch(Exception $e) {}
+        } catch(\Exception $e) {}
 
         return false;
     }
@@ -81,7 +81,7 @@ class BackgroundProcess
             if (!preg_match('/No such process/', $result)) {
                 return true;
             }
-        } catch (Exception $e) {}
+        } catch (\Exception $e) {}
 
         return false;
     }


### PR DESCRIPTION
Calling the Exception class from within a namespace has php assuming Exception is a class belonging to the namespace, can be fixed by prepending the class name with "\".